### PR TITLE
Allow to resize the SVG when the window is resized

### DIFF
--- a/src/ChordDiagram.js
+++ b/src/ChordDiagram.js
@@ -9,6 +9,8 @@ import Svg from './Svg';
 import Groups from './Groups';
 import Ribbons from './Ribbons';
 
+import './main.css'
+
 export default class ChordDiagram extends Component {
     static propTypes = {
         matrix: PropTypes.array.isRequired,

--- a/src/Svg.js
+++ b/src/Svg.js
@@ -8,11 +8,18 @@ const Svg = ({
     className,
     children
 }) => (
-    <svg width={width} height={height} style={style} className={className}>
-        <g transform={`translate(${width / 2},${height / 2})`}>
-            { children }
-        </g>
-    </svg>
+    <div className="svg-container">
+        <svg
+            style={style}
+            className={`svg-content ${className}`}
+            viewBox={`-${width / 2} -${height / 2} ${width} ${height}`}
+            preserveAspectRatio={"xMidYMid meet"}
+        >
+            <g>
+                { children }
+            </g>
+        </svg>
+    </div>
 );
 
 Svg.propTypes = {

--- a/src/main.css
+++ b/src/main.css
@@ -1,0 +1,16 @@
+
+.svg-container {
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  padding-bottom: 100%;
+  vertical-align: top;
+  overflow: hidden;
+}
+
+.svg-content {
+  display: inline-block;
+  position: absolute;
+  top: 0;
+  left: 0;
+}


### PR DESCRIPTION
For my project, I've a problem with `transform={`translate(${width / 2},${height / 2})`}`

I've two version, the first with `css` file secondly with inline styling.
 * The first version need to modify the build. I don't know why but the `npm run build` doesn't deploy css file. We need to execute this: `npm run build -- --copy-files`
 * Otherwise I can use inline styling to `Svg.js` like this: 
```
const divStyle = {
    display: 'inline-block',
    position: 'relative',
    width: '100%',
    paddingBottom: '100%',
    verticalAlign: 'top',
    overflow: 'hidden',
}

const svgStyle = {
    display: 'inline-block',
    position: 'absolute',
    top: 0,
    left: 0,
}
```