### PR TITLE
Optional Ribbon Hover and Hover Persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ Whether to blur other ribbons instead of hiding them on hover.
 
 default: false
 
+### persistHoverOnClick
+
+- type: `boolean`
+
+If true, ribbons highlighted on hover will remain highlighted if you click on
+the element causing the hover. Click anywhere on the SVG to clear this state.
+
+default: false
 
 ### ribbonOpacity
 

--- a/README.md
+++ b/README.md
@@ -160,9 +160,52 @@ default: #000000
 
 - type: `boolean`
 
+Whether to hide other ribbons while mousing over a particular group or ribbon.
+This overrides the individual group / ribbon hover settings.
+
+default: false
+
+### disableGroupHover
+
+- type: `boolean`
+
 Whether to hide other ribbons while mousing over a particular group.
 
 default: false
+
+### disableRibbonHover
+
+- type: `boolean`
+
+Whether to hide other ribbons while mousing over a particular ribbon.
+
+default: false
+
+### blurOnHover
+
+- type: `boolean`
+
+Whether to blur other ribbons instead of hiding them on hover.
+
+default: false
+
+
+### ribbonOpacity
+
+- type: `string`
+
+Default opacity value for ribbons.
+
+default: '0.67'
+
+### ribbonBlurOpacity
+
+- type: `string`
+
+If `blurOnHover` is true, then set 'hidden' ribbons to this opacity instead of
+hiding them.
+
+default: '0.2'
 
 ### strokeWidth
 

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -33,13 +33,12 @@ class Demo extends Component {
           style={{fontFamily: 'sans-serif'}}
           groupLabels={['black', 'yellow', 'brown', 'orange']}
           groupColors={['black', 'yellow', 'brown', 'orange']}
-          groupOnClick={(idx) => alert('Clicked group: ' + idx)}
-          ribbonOnClick={(idx) => alert('Clicked ribbon: ' + idx)}
           disableRibbonHover={false}
           blurOnHover={true}
           ribbonOpacity={'0.8'}
           ribbonBlurOpacity={'0.2'}
           strokeWidth={0}
+          persistHoverOnClick={true}
         />
       </div>
     )

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -12,15 +12,37 @@ const matrix = [
 
 class Demo extends Component {
   render() {
-    return <ChordDiagram
-        matrix={matrix}
-        componentId={1}
-        style={{fontFamily: 'sans-serif'}}
-        groupLabels={['black', 'yellow', 'brown', 'orange']}
-        groupColors={['black', 'yellow', 'brown', 'orange']}
-        groupOnClick={(idx) => alert('Clicked group: ' + idx)}
-        ribbonOnClick={(idx) => alert('Clicked ribbon: ' + idx)}
-    />
+    return (
+      <div style={{display: 'flex'}}>
+        <ChordDiagram
+          matrix={matrix}
+          componentId={1}
+          style={{fontFamily: 'sans-serif'}}
+          groupLabels={['black', 'yellow', 'brown', 'orange']}
+          groupColors={['black', 'yellow', 'brown', 'orange']}
+          groupOnClick={(idx) => alert('Clicked group: ' + idx)}
+          ribbonOnClick={(idx) => alert('Clicked ribbon: ' + idx)}
+          height={600}
+          width={600}
+        />
+        <ChordDiagram
+          height={600}
+          width={600}
+          matrix={matrix}
+          componentId={2}
+          style={{fontFamily: 'sans-serif'}}
+          groupLabels={['black', 'yellow', 'brown', 'orange']}
+          groupColors={['black', 'yellow', 'brown', 'orange']}
+          groupOnClick={(idx) => alert('Clicked group: ' + idx)}
+          ribbonOnClick={(idx) => alert('Clicked ribbon: ' + idx)}
+          disableRibbonHover={false}
+          blurOnHover={true}
+          ribbonOpacity={'0.8'}
+          ribbonBlurOpacity={'0.2'}
+          strokeWidth={0}
+        />
+      </div>
+    )
   }
 }
 

--- a/src/ChordDiagram.js
+++ b/src/ChordDiagram.js
@@ -29,10 +29,15 @@ export default class ChordDiagram extends Component {
         sortChords: PropTypes.func,
         labelColors: PropTypes.array,
         disableHover: PropTypes.bool,
+        disableGroupHover: PropTypes.bool,
+        disableRibbonHover: PropTypes.bool,
         strokeWidth: PropTypes.number,
         resizeWithWindow: PropTypes.bool,
         groupOnClick: PropTypes.func,
         ribbonOnClick: PropTypes.func,
+        blurOnHover: PropTypes.bool,
+        ribbonOpacity: PropTypes.string,
+        ribbonHoverOpacity: PropTypes.string,
     };
 
     static defaultProps = {
@@ -53,23 +58,34 @@ export default class ChordDiagram extends Component {
         sortChords: null,
         labelColors: ['#000000'],
         disableHover: false,
+        disableGroupHover: false,
+        disableRibbonHover: true,
         strokeWidth: 1,
         resizeWithWindow: false,
         ribbonOnClick: null,
+        blurOnHover: false,
+        ribbonOpacity: '0.67',
+        ribbonHoverOpacity: '0.2',
     };
 
     constructor (props) {
         super(props);
 
         this.setMouseOverGroup = this.setMouseOverGroup.bind(this);
+        this.setMouseOverRibbon = this.setMouseOverRibbon.bind(this);
     }
 
     state = {
-        mouseOverGroup: null
+        mouseOverGroup: null,
+        mouseOverRibbon: null,
     };
 
     setMouseOverGroup (mouseOverGroup) {
         this.setState({mouseOverGroup});
+    }
+
+    setMouseOverRibbon (mouseOverRibbon) {
+        this.setState({mouseOverRibbon});
     }
 
     render() {
@@ -89,9 +105,14 @@ export default class ChordDiagram extends Component {
             sortChords,
             labelColors,
             disableHover,
+            disableGroupHover,
+            disableRibbonHover,
             strokeWidth,
             resizeWithWindow,
             ribbonOnClick,
+            blurOnHover,
+            ribbonOpacity,
+            ribbonBlurOpacity,
         } = this.props;
 
         const outerRadius = this.props.outerRadius || Math.min(width, height) * 0.5 - 40;
@@ -133,17 +154,23 @@ export default class ChordDiagram extends Component {
                     setMouseOverGroup={this.setMouseOverGroup}
                     groupLabels={groupLabels}
                     labelColors={labelColors}
-                    disableHover={disableHover}
+                    disableHover={disableHover || disableGroupHover}
                     onClick={groupOnClick}
                 />
 
                 <Ribbons
                     chords={chords}
                     color={color}
+                    disableHover={disableHover || disableRibbonHover}
                     ribbon={d3Ribbon}
+                    setMouseOverRibbon={this.setMouseOverRibbon}
                     mouseOverGroup={this.state.mouseOverGroup}
+                    mouseOverRibbon={this.state.mouseOverRibbon}
                     strokeWidth={strokeWidth}
                     onClick={ribbonOnClick}
+                    blurOnHover={blurOnHover}
+                    ribbonOpacity={ribbonOpacity}
+                    ribbonBlurOpacity={ribbonBlurOpacity}
                 />
             </Svg>
         );

--- a/src/ChordDiagram.js
+++ b/src/ChordDiagram.js
@@ -38,6 +38,7 @@ export default class ChordDiagram extends Component {
         blurOnHover: PropTypes.bool,
         ribbonOpacity: PropTypes.string,
         ribbonHoverOpacity: PropTypes.string,
+        persistHoverOnClick: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -66,19 +67,33 @@ export default class ChordDiagram extends Component {
         blurOnHover: false,
         ribbonOpacity: '0.67',
         ribbonHoverOpacity: '0.2',
+        persistHoverOnClick: false,
     };
 
     constructor (props) {
         super(props);
 
+        this.clearHover = this.clearHover.bind(this);
+        this.setHoverPersist = this.setHoverPersist.bind(this);
         this.setMouseOverGroup = this.setMouseOverGroup.bind(this);
         this.setMouseOverRibbon = this.setMouseOverRibbon.bind(this);
     }
 
     state = {
+        hoverPersist: false,
         mouseOverGroup: null,
         mouseOverRibbon: null,
     };
+
+    clearHover() {
+        this.setState({ hoverPersist: false, mouseOverGroup: null, mouseOverRibbon: null })
+    }
+
+    setHoverPersist (hoverPersist) {
+        if (this.props.persistHoverOnClick) {
+            this.setState({hoverPersist});
+        }
+    }
 
     setMouseOverGroup (mouseOverGroup) {
         this.setState({mouseOverGroup});
@@ -113,6 +128,7 @@ export default class ChordDiagram extends Component {
             blurOnHover,
             ribbonOpacity,
             ribbonBlurOpacity,
+            persistHoverOnClick,
         } = this.props;
 
         const outerRadius = this.props.outerRadius || Math.min(width, height) * 0.5 - 40;
@@ -143,6 +159,7 @@ export default class ChordDiagram extends Component {
                 height={height}
                 style={style}
                 className={className}
+                clearHover={this.clearHover}
                 resizeWithWindow={resizeWithWindow}
             >
                 <Groups
@@ -155,6 +172,8 @@ export default class ChordDiagram extends Component {
                     groupLabels={groupLabels}
                     labelColors={labelColors}
                     disableHover={disableHover || disableGroupHover}
+                    hoverPersist={this.state.hoverPersist}
+                    setHoverPersist={this.setHoverPersist}
                     onClick={groupOnClick}
                 />
 
@@ -167,6 +186,8 @@ export default class ChordDiagram extends Component {
                     mouseOverGroup={this.state.mouseOverGroup}
                     mouseOverRibbon={this.state.mouseOverRibbon}
                     strokeWidth={strokeWidth}
+                    hoverPersist={this.state.hoverPersist}
+                    setHoverPersist={this.setHoverPersist}
                     onClick={ribbonOnClick}
                     blurOnHover={blurOnHover}
                     ribbonOpacity={ribbonOpacity}

--- a/src/Groups.js
+++ b/src/Groups.js
@@ -14,15 +14,17 @@ const Groups = ({
     groupLabels,
     labelColors,
     disableHover,
+    hoverPersist,
+    setHoverPersist,
     onClick,
 }) => (
     <g className="groups">
         {chords.groups.map((group, groupIndex) => (
             <g
                 key={groupIndex}
-                onMouseOver={!disableHover ? () => setMouseOverGroup(group.index) : null}
-                onMouseOut={!disableHover ? () => setMouseOverGroup(null) : null}
-                onClick={ () => onClick(group.index) }
+                onMouseOver={(!disableHover && !hoverPersist) ? () => setMouseOverGroup(group.index) : null}
+                onMouseOut={(!disableHover && !hoverPersist) ? () => setMouseOverGroup(null) : null}
+                onClick={ () => { setHoverPersist(!hoverPersist); onClick(group.index) } }
             >
                 <path
                     id={`component${componentId}-group${groupIndex}`}
@@ -52,6 +54,7 @@ Groups.propTypes = {
     groupLabels: PropTypes.array,
     labelColors: PropTypes.array,
     disableHover: PropTypes.bool,
+    persistHoverOnClick: PropTypes.bool,
     onClick: PropTypes.func,
 };
 

--- a/src/Ribbons.js
+++ b/src/Ribbons.js
@@ -7,26 +7,44 @@ import { isHiddenRibbon } from './utils';
 const Ribbons = ({
     chords,
     color,
+    disableHover,
     ribbon,
+    setMouseOverRibbon,
     mouseOverGroup,
+    mouseOverRibbon,
     onClick,
-    strokeWidth
+    strokeWidth,
+    blurOnHover,
+    ribbonOpacity,
+    ribbonBlurOpacity,
 }) => (
     <g
         className="ribbons"
-        fillOpacity="0.67"
+        fillOpacity={ribbonOpacity}
     >
-        {chords.map((chord, chordIndex) => (
+        {chords.map((chord, chordIndex) => {
+          const hidden = isHiddenRibbon(mouseOverGroup, chord.source.index, chord.target.index) ||
+                         isHiddenRibbon(mouseOverRibbon, chordIndex, null);
+
+          const style = ( blurOnHover ?
+            { fillOpacity: `${ hidden ? ribbonBlurOpacity : ribbonOpacity }` } :
+            { display: `${hidden ? 'none': 'block'}`, fillOpacity: ribbonOpacity }
+          )
+
+          return (
             <path
                 key={chordIndex}
-                style={{display: `${isHiddenRibbon(mouseOverGroup, chord.source.index, chord.target.index) ? 'none': 'block'}`}}
+                style={style}
                 fill={color(chord.target.index)}
                 stroke={`${rgb(color(chord.target.index)).darker()}`}
                 strokeWidth={strokeWidth}
                 d={`${ribbon({source: chord.source, target: chord.target})}`}
                 onClick={() => onClick(chordIndex) }
+                onMouseOver={!disableHover ? () => setMouseOverRibbon(chordIndex) : null}
+                onMouseOut={!disableHover ? () => setMouseOverRibbon(null) : null}
             />
-        ))}
+          )
+        })}
     </g>
 );
 
@@ -34,9 +52,13 @@ Ribbons.propTypes = {
     chords: PropTypes.array.isRequired,
     color: PropTypes.func.isRequired,
     ribbon: PropTypes.func.isRequired,
+    setMouseOverRibbon: PropTypes.func.isRequired,
     mouseOverGroup: PropTypes.number,
+    mouseOverRibbon: PropTypes.number,
     onClick: PropTypes.func,
     strokeWidth: PropTypes.number,
+    disableHover: PropTypes.bool,
+    blurOnHover: PropTypes.bool,
 };
 
 export default Ribbons;

--- a/src/Ribbons.js
+++ b/src/Ribbons.js
@@ -12,6 +12,8 @@ const Ribbons = ({
     setMouseOverRibbon,
     mouseOverGroup,
     mouseOverRibbon,
+    hoverPersist,
+    setHoverPersist,
     onClick,
     strokeWidth,
     blurOnHover,
@@ -39,9 +41,9 @@ const Ribbons = ({
                 stroke={`${rgb(color(chord.target.index)).darker()}`}
                 strokeWidth={strokeWidth}
                 d={`${ribbon({source: chord.source, target: chord.target})}`}
-                onClick={() => onClick(chordIndex) }
-                onMouseOver={!disableHover ? () => setMouseOverRibbon(chordIndex) : null}
-                onMouseOut={!disableHover ? () => setMouseOverRibbon(null) : null}
+                onClick={() => { setHoverPersist(!hoverPersist); onClick(chordIndex) } }
+                onMouseOver={(!disableHover && !hoverPersist) ? () => setMouseOverRibbon(chordIndex) : null}
+                onMouseOut={(!disableHover && !hoverPersist) ? () => setMouseOverRibbon(null) : null}
             />
           )
         })}

--- a/src/Svg.js
+++ b/src/Svg.js
@@ -6,6 +6,7 @@ const Svg = ({
     height,
     style,
     className,
+    clearHover,
     children,
     resizeWithWindow
 }) => (
@@ -16,6 +17,14 @@ const Svg = ({
             preserveAspectRatio={"xMidYMid meet"}
         >
             <g>
+              <rect
+                fillOpacity={0}
+                height={height}
+                onClick={ () => clearHover() }
+                width={width}
+                x={`-${width / 2}`}
+                y={`-${height / 2}`}
+              />
                 { children }
             </g>
         </svg>


### PR DESCRIPTION
Few new features:

* Option to allow highlighting a single Ribbon on mouseOver
* Option to change ribbon opacity on hover (default to current behavior of hiding)
* Option to persist the highlighted ribbons by clicking on them. onClick continues to work, clicking on the item or blank area of the SVG will reset the persisted state to default.

Updates:
* README on new optional properties
* Added second diagram on demo with lots of features enabled